### PR TITLE
Remove runtime dependency for Go API

### DIFF
--- a/golang.req
+++ b/golang.req
@@ -6,17 +6,6 @@ buildroot = RpmSysinfo.get_buildroot
 contribdir = RpmSysinfo.get_go_contribdir
 importpath = RpmSysinfo.get_go_importpath
 
-def go_get_version()
-  IO.popen("go version") do |process|
-    process.each_line do |l|
-      version_re = /^go version go(\S+)\s+([^\/]+)\/(.*)$/
-      md = version_re.match(l.chomp)
-      # 1:"1.6" 2:"linux" 3:"amd64"
-      return md[1] if md
-    end
-  end
-end
-
 # read stdin for filelist rpm feeds us for a (sub) package
 filelist = []
 ARGF.each do |l|
@@ -32,9 +21,6 @@ end
 requires = []
 
 unless filelist.empty? then
-
-	requires << "golang(API) = " + go_get_version()
-
 	filelist.each do |f|
 		# unarchive .a
 		system("ar -x #{f} __.PKGDEF")
@@ -60,7 +46,7 @@ unless filelist.empty? then
 	end
 
 	requires.each do |p|
-		puts p	
+		puts p
 	end
 
 end


### PR DESCRIPTION
As golang tools are static binaries you should never require the Go API
as a runtime dependency. To get rid of that I have dropped this from
`golang.req`

Signed-off-by: Thomas Boerger tboerger@suse.de
